### PR TITLE
feature: apply CloudReaperDeletionTime tag with scheduled deletion timestamp

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -95,6 +95,7 @@ Requires Docker or Podman for running Azurite (Azure Storage emulator). The proj
 **Tag System (configurable via `LifetimeTagName` / `StatusTagName` environment variables):**
 - `CloudReaperLifetime` - Required tag on resource groups, value is minutes until deletion
 - `CloudReaperStatus` - Applied by the system as "Confirmed" when deletion is scheduled
+- `CloudReaperDeletionTime` - Applied by the system with the ISO 8601 UTC timestamp of the scheduled deletion
 
 ## Infrastructure
 

--- a/.gitignore
+++ b/.gitignore
@@ -356,7 +356,7 @@ MigrationBackup/
 .vscode/
 
 # Local test payloads
-docs/payload.json
+rest/payload.json
 
 # Local hooks
 .github/hooks/superset-notify.json

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Azure Reaper currently has the following limitations:
 | It is not possible to stop the deletion of a scheduled resource group. 😅 However, a lock can be applied to prevent deletion. | ✅ Workaround Available |
 | Azure Reaper has only been tested with a single subscription. Multi-subscription support is planned. | 🔨 Planned Improvement |
 | Azure Reaper operates only at the Azure Resource Group level, not on individual resources | 🗒️ Current Functionality |
+| Azure Reaper uses UTC internally for all scheduling and timestamps (e.g. `CloudReaperDeletionTime`). There is currently no option to configure a different time zone. | 🗒️ Current Functionality |
 | These limitations will be actively addressed in future updates to help make Azure Reaper work and play better. |  |
 ## Status
 Azure Reaper is under active development and is constantly evolving. The capabilities and performance of the project are continually being improved.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Azure Reaper currently has the following limitations:
 | Azure Reaper has only been tested with a single subscription. Multi-subscription support is planned. | 🔨 Planned Improvement |
 | Azure Reaper operates only at the Azure Resource Group level, not on individual resources | 🗒️ Current Functionality |
 | Azure Reaper uses UTC internally for all scheduling and timestamps (e.g. `CloudReaperDeletionTime`). There is currently no option to configure a different time zone. | 🗒️ Current Functionality |
+| Re-scheduling a deletion by updating the `CloudReaperLifetime` tag value after the resource group has already been scheduled is not supported. The original schedule remains active. | 🗒️ Current Functionality |
 | These limitations will be actively addressed in future updates to help make Azure Reaper work and play better. |  |
 ## Status
 Azure Reaper is under active development and is constantly evolving. The capabilities and performance of the project are continually being improved.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Azure Reaper uses specific tags to manage the lifecycle of Azure resource groups
 | ----- | ----- | ----- | ----- | ----- |
 | CloudReaperLifetime | This tag is applied when the resource group is created by the engineer. It specifies the lifespan of the resource group in minutes before it should be deleted. The value must be a positive integer (> 0). Values of 0, negative numbers, or non-integer strings are ignored. Configurable via `LifetimeTagName`. | 60 (for 60 minutes lifetime) | User |  |
 | CloudReaperStatus | This tag is applied by Azure Reaper after successful validation and scheduling of the resource group’s deletion. It indicates that the resource group is confirmed for deletion. Configurable via `StatusTagName`. | Confirmed | Azure Reaper | Can be used to return comments or error messages from Azure Reaper |
-| CloudReaperDeletionTime | Could be used to message back the exact time and date of the scheduled death. | 2024-05-31T15:30:00Z | Azure Reaper | Not yet implmeneted! |
+| CloudReaperDeletionTime | Applied by Azure Reaper after scheduling deletion. Shows the exact UTC timestamp when the resource group will be deleted (ISO 8601 format). Configurable via `DeletionTimeTagName`. | 2024-05-31T15:30:00.0000000+00:00 | Azure Reaper |  |
 ## Limitations
 Azure Reaper currently has the following limitations:
 
@@ -250,6 +250,7 @@ Configured in `src/AzureReaper.Functions/local.settings.json` (see [`local.setti
 | `FUNCTIONS_WORKER_RUNTIME` | `dotnet-isolated` | Yes | Required for the isolated worker model |
 | `LifetimeTagName` | `CloudReaperLifetime` | No | Custom tag name for resource group lifetime (minutes) |
 | `StatusTagName` | `CloudReaperStatus` | No | Custom tag name applied when deletion is scheduled |
+| `DeletionTimeTagName` | `CloudReaperDeletionTime` | No | Custom tag name for the scheduled deletion timestamp |
 
 ### Dev Container
 

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -91,6 +91,7 @@ resource "azurerm_function_app_flex_consumption" "reaper" {
     "AzureWebJobsStorage__credential"  = "managedidentity"
     "LifetimeTagName"                  = var.lifetime_tag_name
     "StatusTagName"                    = var.status_tag_name
+    "DeletionTimeTagName"              = var.deletion_time_tag_name
   }
 
   tags = merge(local.default_tags, {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -89,3 +89,9 @@ variable "status_tag_name" {
   description = "Tag name for reaper status tracking"
   default     = "CloudReaperStatus"
 }
+
+variable "deletion_time_tag_name" {
+  type        = string
+  description = "Tag name for the scheduled deletion timestamp"
+  default     = "CloudReaperDeletionTime"
+}

--- a/src/AzureReaper.Functions/Entities/AzureResourceEntity.cs
+++ b/src/AzureReaper.Functions/Entities/AzureResourceEntity.cs
@@ -17,6 +17,7 @@ public class AzureResourceEntity(
 {
     private readonly string _lifetimeTagName = configuration.GetValue<string>("LifetimeTagName") ?? "CloudReaperLifetime";
     private readonly string _statusTagName = configuration.GetValue<string>("StatusTagName") ?? "CloudReaperStatus";
+    private readonly string _deletionTimeTagName = configuration.GetValue<string>("DeletionTimeTagName") ?? "CloudReaperDeletionTime";
 
     public async Task InitializeEntityAsync(ResourcePayload resourcePayload)
     {
@@ -51,7 +52,7 @@ public class AzureResourceEntity(
             return;
         }
 
-        SetSchedule(lifetimeMinutes.Value);
+        await SetScheduleAsync(lifetimeMinutes.Value);
     }
 
     private async Task<int?> ValidateResourceGroupEligibility()
@@ -108,7 +109,7 @@ public class AzureResourceEntity(
         }
     }
 
-    private void SetSchedule(int lifetimeMinutes)
+    private async Task SetScheduleAsync(int lifetimeMinutes)
     {
         var signalTime = DateTimeOffset.UtcNow.AddMinutes(lifetimeMinutes);
         var signalOptions = new SignalEntityOptions
@@ -119,6 +120,17 @@ public class AzureResourceEntity(
 
         State.Scheduled = true;
         State.DeletionScheduledAt = signalTime;
+
+        try
+        {
+            await azureResourceService.ApplyResourceGroupTags(State.SubscriptionId!, State.ResourceGroupName!,
+                _deletionTimeTagName, signalTime.ToString("o"));
+            logger.LogInformation("[EntityTrigger] Applied '{tag}' = '{time}' to Resource Group '{rg}'", _deletionTimeTagName, signalTime.ToString("o"), State.ResourceGroupName);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            logger.LogWarning("[EntityTrigger] Resource Group '{rg}' was deleted before deletion time tag could be applied", State.ResourceGroupName);
+        }
 
         logger.LogInformation("[EntityTrigger] Scheduled deletion of Resource Group '{rg}' at {time}", State.ResourceGroupName, signalTime);
     }

--- a/src/AzureReaper.Functions/local.settings.sample.json
+++ b/src/AzureReaper.Functions/local.settings.sample.json
@@ -4,6 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "LifetimeTagName": "CloudReaperLifetime",
-    "StatusTagName": "CloudReaperStatus"
+    "StatusTagName": "CloudReaperStatus",
+    "DeletionTimeTagName": "CloudReaperDeletionTime"
   }
 }


### PR DESCRIPTION
## Summary

- Implement the `CloudReaperDeletionTime` tag that writes the scheduled deletion timestamp (ISO 8601) back to the resource group, giving users immediate visibility into when their resources will be deleted
- Tag name is configurable via the `DeletionTimeTagName` environment variable (default: `CloudReaperDeletionTime`)
- No new files or service layer changes — reuses existing `ApplyResourceGroupTags()` method

Closes #62

## Test plan

- [x] `dotnet build` compiles with zero warnings/errors
- [x] Run locally with `func start`, send an EventGrid payload for a tagged resource group, and verify the `CloudReaperDeletionTime` tag appears with a valid ISO 8601 timestamp
- [x] Confirm the tag value matches the scheduled deletion time shown in the logs
- [x] Verify custom tag name works by setting `DeletionTimeTagName` in `local.settings.json`