### PR TITLE
feature: cancel scheduled deletion by removing CloudReaperLifetime tag

### DIFF
--- a/src/AzureReaper.Functions/Entities/AzureResourceEntity.cs
+++ b/src/AzureReaper.Functions/Entities/AzureResourceEntity.cs
@@ -137,6 +137,45 @@ public class AzureResourceEntity(
 
     public async Task DeleteResourceAsync()
     {
+        // Re-fetch the resource group to check current tag state
+        var rg = await azureResourceService.GetAzureResourceGroup(State.SubscriptionId!, State.ResourceGroupName!);
+
+        if (rg is null)
+        {
+            logger.LogWarning("[EntityTrigger] Resource Group '{rg}' no longer exists. Cleaning up entity.", State.ResourceGroupName);
+            State = null!;
+            return;
+        }
+
+        // Check if the lifetime tag was removed (user cancelled deletion)
+        if (!rg.Data.Tags.ContainsKey(_lifetimeTagName))
+        {
+            logger.LogInformation("[EntityTrigger] Lifetime tag '{tag}' removed from Resource Group '{rg}'. Cancelling scheduled deletion.",
+                _lifetimeTagName, State.ResourceGroupName);
+
+            // Clean up reaper metadata tags if they exist
+            try
+            {
+                if (rg.Data.Tags.ContainsKey(_statusTagName))
+                {
+                    await azureResourceService.RemoveResourceGroupTag(State.SubscriptionId!, State.ResourceGroupName!, _statusTagName);
+                }
+
+                if (rg.Data.Tags.ContainsKey(_deletionTimeTagName))
+                {
+                    await azureResourceService.RemoveResourceGroupTag(State.SubscriptionId!, State.ResourceGroupName!, _deletionTimeTagName);
+                }
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                logger.LogWarning("[EntityTrigger] Resource Group '{rg}' was deleted before cleanup tags could be removed", State.ResourceGroupName);
+            }
+
+            State = null!;
+            return;
+        }
+
+        // Lifetime tag still present - proceed with deletion
         try
         {
             await azureResourceService.DeleteResourceGroupAsync(State.SubscriptionId!, State.ResourceGroupName!);

--- a/src/AzureReaper.Functions/Entities/AzureResourceEntity.cs
+++ b/src/AzureReaper.Functions/Entities/AzureResourceEntity.cs
@@ -153,7 +153,7 @@ public class AzureResourceEntity(
             logger.LogInformation("[EntityTrigger] Lifetime tag '{tag}' removed from Resource Group '{rg}'. Cancelling scheduled deletion.",
                 _lifetimeTagName, State.ResourceGroupName);
 
-            // Clean up reaper metadata tags if they exist
+            // Clean up reaper metadata tags (best-effort — entity cleanup must not be blocked by tag removal failures)
             try
             {
                 if (rg.Data.Tags.ContainsKey(_statusTagName))
@@ -166,9 +166,9 @@ public class AzureResourceEntity(
                     await azureResourceService.RemoveResourceGroupTag(State.SubscriptionId!, State.ResourceGroupName!, _deletionTimeTagName);
                 }
             }
-            catch (RequestFailedException ex) when (ex.Status == 404)
+            catch (RequestFailedException ex)
             {
-                logger.LogWarning("[EntityTrigger] Resource Group '{rg}' was deleted before cleanup tags could be removed", State.ResourceGroupName);
+                logger.LogWarning(ex, "[EntityTrigger] Failed to remove cleanup tags from Resource Group '{rg}'. Entity will still be cleaned up.", State.ResourceGroupName);
             }
 
             State = null!;

--- a/src/AzureReaper.Functions/Interfaces/IAzureResourceService.cs
+++ b/src/AzureReaper.Functions/Interfaces/IAzureResourceService.cs
@@ -6,5 +6,6 @@ public interface IAzureResourceService
 {
     Task<ResourceGroupResource?> GetAzureResourceGroup(string subscriptionId, string resourceGroupName);
     Task ApplyResourceGroupTags(string subscriptionId, string resourceGroupName, string tagName, string tagValue);
+    Task RemoveResourceGroupTag(string subscriptionId, string resourceGroupName, string tagName);
     Task DeleteResourceGroupAsync(string subscriptionId, string resourceGroupName);
 }

--- a/src/AzureReaper.Functions/Services/AzureResourceService.cs
+++ b/src/AzureReaper.Functions/Services/AzureResourceService.cs
@@ -35,6 +35,14 @@ public class AzureResourceService(ArmClient armClient, ILogger<AzureResourceServ
         logger.LogInformation("[AzureResourceService] Tags applied to Resource Group '{resourceGroup}'", resourceGroupName);
     }
 
+    public async Task RemoveResourceGroupTag(string subscriptionId, string resourceGroupName, string tagName)
+    {
+        var resourceGroupIdentifier = ResourceGroupResource.CreateResourceIdentifier(subscriptionId, resourceGroupName);
+        var rg = armClient.GetResourceGroupResource(resourceGroupIdentifier);
+        await rg.RemoveTagAsync(tagName);
+        logger.LogInformation("[AzureResourceService] Tag '{tagName}' removed from Resource Group '{resourceGroup}'", tagName, resourceGroupName);
+    }
+
     public async Task DeleteResourceGroupAsync(string subscriptionId, string resourceGroupName)
     {
         var resourceGroupIdentifier = ResourceGroupResource.CreateResourceIdentifier(subscriptionId, resourceGroupName);


### PR DESCRIPTION
## Summary

- Adds pre-deletion check: before deleting a resource group, Cloud Reaper re-fetches it and verifies the `CloudReaperLifetime` tag still exists
- If the tag was removed, cancels the deletion, cleans up `CloudReaperStatus` and `CloudReaperDeletionTime` tags, and destroys the durable entity
- Adds `RemoveResourceGroupTag` to `IAzureResourceService` and `AzureResourceService`

Closes #64

## Test plan

- [x] Deploy or run locally with `func start`
- [x] Create a resource group with a `CloudReaperLifetime` tag and verify deletion gets scheduled
- [x] Remove the `CloudReaperLifetime` tag before the scheduled time — verify deletion is cancelled and metadata tags are cleaned up
- [x] Keep the tag and verify deletion proceeds as before
- [x] Delete the resource group externally before the scheduled time — verify entity cleans up gracefully