### PR TITLE
feature: v2.0.0 release preparation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -99,7 +99,7 @@ Requires Docker or Podman for running Azurite (Azure Storage emulator). The proj
 
 ## Infrastructure
 
-Infrastructure as Code is in `infra/main.bicep` (subscription-scoped deployment).
+Infrastructure as Code is managed with Terraform in the `infra/` directory.
 
 ## Development Guidelines
 
@@ -125,4 +125,4 @@ Always prefer the **isolated worker model** patterns over the legacy in-process 
 - Durable Functions with Distributed Tracing V2 enabled
 - Azure SDK (Azure.ResourceManager, Azure.Identity)
 - EventGrid triggers
-- Planned: Azure Developer CLI (`azd`) for deployment, GitHub Actions for CI/CD
+- Azure Developer CLI (`azd`) for deployment

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,7 @@
 				"ms-vscode.azurecli",
 				"ms-dotnettools.csharp",
 				"ms-dotnettools.vscode-dotnet-runtime",
-				"ms-azuretools.vscode-bicep",
+				"hashicorp.terraform",
 				"ms-vscode.vscode-node-azure-pack",
 				"vscodevim.vim",
 				"ms-azuretools.azure-dev",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,11 @@ updates:
    directory: "/"
    schedule:
      interval: weekly
+ - package-ecosystem: "nuget"
+   directory: "/src/AzureReaper.Functions"
+   schedule:
+     interval: weekly
+ - package-ecosystem: "terraform"
+   directory: "/infra"
+   schedule:
+     interval: weekly

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 # Azure Reaper
 **In the age-old dance of creation and destruction, behold Azure Reaper, a guardian wrought in code and cloud. Its purpose noble, it wields the power to vanquish Azure resources marked by time’s decree, ensuring realms of development and testing stand uncluttered, their legacies preserved in the annals of digital lore.**
 
->  [!IMPORTANT]
-Please note that Azure Reaper is currently undergoing a major rewrite to leverage the latest .NET and Azure Functions frameworks. The version available on the main branch is under active development and may be unstable. For those interested in the previous stable version, it can be found in the ./archive directory of this repository. I appreciate your interest and patience as I am working to improve the capabilities and performance of Azure Reaper.
+> [!NOTE]
+> Azure Reaper has been completely rewritten for v2.0.0 using .NET 10 and the Azure Functions isolated worker model. If you are interested in the original version, check out the `./archive` directory.
 
 Azure Reaper is a automation tool built on the robust foundation of Azure Functions to streamline the management of your cloud environment. This solution specializes in automatically deleting groups of resources tagged to your specifications, making it ideal for development and test environments. With Azure Reaper, you not only save money by eliminating unnecessary resource sprawl, but you also reduce the burden of manual cleanup. Leverage this seamless integration into your workflow to increase efficiency, reduce costs, and maintain a focused, clutter-free cloud environment.
 The idea is based on Jeff Holan's great [﻿functions-csharp-entities-grimreaper](https://github.com/jeffhollan/functions-csharp-entities-grimreaper), rewritten in a more simple form without the Twilio SMS part.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 > [!NOTE]
 > Cloud Reaper for Azure has been completely rewritten for v2.0.0 using .NET 10 and the Azure Functions isolated worker model. If you are interested in the original version, check out the `./archive` directory.
 
-Cloud Reaper for Azure is a automation tool built on the robust foundation of Azure Functions to streamline the management of your cloud environment. This solution specializes in automatically deleting groups of resources tagged to your specifications, making it ideal for development and test environments. With Cloud Reaper for Azure, you not only save money by eliminating unnecessary resource sprawl, but you also reduce the burden of manual cleanup. Leverage this seamless integration into your workflow to increase efficiency, reduce costs, and maintain a focused, clutter-free cloud environment.
-The idea is based on Jeff Holan's great [﻿functions-csharp-entities-grimreaper](https://github.com/jeffhollan/functions-csharp-entities-grimreaper), rewritten in a more simple form without the Twilio SMS part.
+Cloud Reaper for Azure automatically deletes tagged Azure resource groups after a specified lifetime -- keeping dev and test subscriptions clean and your cloud bill in check. Tag a resource group, walk away, and let the reaper handle the rest.
+
+Inspired by Jeff Holan's [functions-csharp-entities-grimreaper](https://github.com/jeffhollan/functions-csharp-entities-grimreaper), rebuilt from the ground up with .NET 10, Azure Functions isolated worker model, and Durable Entities.
 
 ## Architecture
 ![Cloud Reaper for Azure - Workflow](./assets/azure_reaper_architecture.png "Cloud Reaper for Azure - Workflow")

--- a/README.md
+++ b/README.md
@@ -1,47 +1,47 @@
-![Azure Reaper banner](./assets/reaper_banner_v2.png "")
+![Cloud Reaper for Azure banner](./assets/reaper_banner_v2.png "")
 
-# Azure Reaper
-**In the age-old dance of creation and destruction, behold Azure Reaper, a guardian wrought in code and cloud. Its purpose noble, it wields the power to vanquish Azure resources marked by time’s decree, ensuring realms of development and testing stand uncluttered, their legacies preserved in the annals of digital lore.**
+# Cloud Reaper for Azure
+**In the age-old dance of creation and destruction, behold Cloud Reaper for Azure, a guardian wrought in code and cloud. Its purpose noble, it wields the power to vanquish Azure resources marked by time’s decree, ensuring realms of development and testing stand uncluttered, their legacies preserved in the annals of digital lore.**
 
 > [!NOTE]
-> Azure Reaper has been completely rewritten for v2.0.0 using .NET 10 and the Azure Functions isolated worker model. If you are interested in the original version, check out the `./archive` directory.
+> Cloud Reaper for Azure has been completely rewritten for v2.0.0 using .NET 10 and the Azure Functions isolated worker model. If you are interested in the original version, check out the `./archive` directory.
 
-Azure Reaper is a automation tool built on the robust foundation of Azure Functions to streamline the management of your cloud environment. This solution specializes in automatically deleting groups of resources tagged to your specifications, making it ideal for development and test environments. With Azure Reaper, you not only save money by eliminating unnecessary resource sprawl, but you also reduce the burden of manual cleanup. Leverage this seamless integration into your workflow to increase efficiency, reduce costs, and maintain a focused, clutter-free cloud environment.
+Cloud Reaper for Azure is a automation tool built on the robust foundation of Azure Functions to streamline the management of your cloud environment. This solution specializes in automatically deleting groups of resources tagged to your specifications, making it ideal for development and test environments. With Cloud Reaper for Azure, you not only save money by eliminating unnecessary resource sprawl, but you also reduce the burden of manual cleanup. Leverage this seamless integration into your workflow to increase efficiency, reduce costs, and maintain a focused, clutter-free cloud environment.
 The idea is based on Jeff Holan's great [﻿functions-csharp-entities-grimreaper](https://github.com/jeffhollan/functions-csharp-entities-grimreaper), rewritten in a more simple form without the Twilio SMS part.
 
 ## Architecture
 ![Cloud Reaper for Azure - Workflow](./assets/azure_reaper_architecture.png "Cloud Reaper for Azure - Workflow")
 
 ## Tags
-Azure Reaper uses specific tags to manage the lifecycle of Azure resource groups. Tag names are configurable via environment variables (`LifetimeTagName`, `StatusTagName`). Below are the default tags and their use cases:
+Cloud Reaper for Azure uses specific tags to manage the lifecycle of Azure resource groups. Tag names are configurable via environment variables (`LifetimeTagName`, `StatusTagName`). Below are the default tags and their use cases:
 
 | Tag Name | Description | Example Value | Responsibility | Comments |
 | ----- | ----- | ----- | ----- | ----- |
 | CloudReaperLifetime | This tag is applied when the resource group is created by the engineer. It specifies the lifespan of the resource group in minutes before it should be deleted. The value must be a positive integer (> 0). Values of 0, negative numbers, or non-integer strings are ignored. Configurable via `LifetimeTagName`. | 60 (for 60 minutes lifetime) | User |  |
-| CloudReaperStatus | This tag is applied by Azure Reaper after successful validation and scheduling of the resource group’s deletion. It indicates that the resource group is confirmed for deletion. Configurable via `StatusTagName`. | Confirmed | Azure Reaper | Can be used to return comments or error messages from Azure Reaper |
-| CloudReaperDeletionTime | Applied by Azure Reaper after scheduling deletion. Shows the exact UTC timestamp when the resource group will be deleted (ISO 8601 format). Configurable via `DeletionTimeTagName`. | 2024-05-31T15:30:00.0000000+00:00 | Azure Reaper |  |
+| CloudReaperStatus | This tag is applied by Cloud Reaper for Azure after successful validation and scheduling of the resource group’s deletion. It indicates that the resource group is confirmed for deletion. Configurable via `StatusTagName`. | Confirmed | Cloud Reaper for Azure | Can be used to return comments or error messages from Cloud Reaper for Azure |
+| CloudReaperDeletionTime | Applied by Cloud Reaper for Azure after scheduling deletion. Shows the exact UTC timestamp when the resource group will be deleted (ISO 8601 format). Configurable via `DeletionTimeTagName`. | 2024-05-31T15:30:00.0000000+00:00 | Cloud Reaper for Azure |  |
 ## Limitations
-Azure Reaper currently has the following limitations:
+Cloud Reaper for Azure currently has the following limitations:
 
 | Description | Status |
 | ----- | ----- |
 | It is not possible to stop the deletion of a scheduled resource group. 😅 However, a lock can be applied to prevent deletion. | ✅ Workaround Available |
-| Azure Reaper has only been tested with a single subscription. Multi-subscription support is planned. | 🔨 Planned Improvement |
-| Azure Reaper operates only at the Azure Resource Group level, not on individual resources | 🗒️ Current Functionality |
-| Azure Reaper uses UTC internally for all scheduling and timestamps (e.g. `CloudReaperDeletionTime`). There is currently no option to configure a different time zone. | 🗒️ Current Functionality |
+| Cloud Reaper for Azure has only been tested with a single subscription. Multi-subscription support is planned. | 🔨 Planned Improvement |
+| Cloud Reaper for Azure operates only at the Azure Resource Group level, not on individual resources | 🗒️ Current Functionality |
+| Cloud Reaper for Azure uses UTC internally for all scheduling and timestamps (e.g. `CloudReaperDeletionTime`). There is currently no option to configure a different time zone. | 🗒️ Current Functionality |
 | Re-scheduling a deletion by updating the `CloudReaperLifetime` tag value after the resource group has already been scheduled is not supported. The original schedule remains active. | 🗒️ Current Functionality |
-| These limitations will be actively addressed in future updates to help make Azure Reaper work and play better. |  |
+| These limitations will be actively addressed in future updates to help make Cloud Reaper for Azure work and play better. |  |
 ## Status
-Azure Reaper is under active development and is constantly evolving. The capabilities and performance of the project are continually being improved.
+Cloud Reaper for Azure is under active development and is constantly evolving. The capabilities and performance of the project are continually being improved.
 
 # Deployment guide
 
 ![Cloud Reaper for Azure - Deployment Flow](./assets/azure_reaper_deployment_flow.png "Cloud Reaper for Azure - Deployment Flow")
 
 > [!WARNING]
-> Azure Reaper uses a custom role that grants its managed identity permission to read, modify tags on, and **delete** any resource group in the target subscription. While this role is scoped to resource group lifecycle operations only, it is still highly privileged. Deployment is recommended for **test and development subscriptions only**. Do not deploy to production subscriptions without a thorough security review.
+> Cloud Reaper for Azure uses a custom role that grants its managed identity permission to read, modify tags on, and **delete** any resource group in the target subscription. While this role is scoped to resource group lifecycle operations only, it is still highly privileged. Deployment is recommended for **test and development subscriptions only**. Do not deploy to production subscriptions without a thorough security review.
 
-Azure Reaper is deployed with Azure Developer CLI (`azd`) and Terraform.
+Cloud Reaper for Azure is deployed with Azure Developer CLI (`azd`) and Terraform.
 
 ## Prerequisites
 
@@ -218,7 +218,7 @@ az account show
 
 **2. Rewrite the EventGrid payload**
 
-Open `rest/eventgrid.http` (or `rest/payload.example.json`) and replace every `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` subscription placeholder with your real subscription ID. Then set the resource group name to the one you want Azure Reaper to target.
+Open `rest/eventgrid.http` (or `rest/payload.example.json`) and replace every `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` subscription placeholder with your real subscription ID. Then set the resource group name to the one you want Cloud Reaper for Azure to target.
 
 The two fields that matter most are `subject` and `data.resourceUri` — they must contain the full resource ID of the target resource group:
 
@@ -240,7 +240,7 @@ Also update these fields to match:
 
 **3. Send the request**
 
-Fire the modified payload against the local function app as described in [Testing the EventGrid Trigger](#testing-the-eventgrid-trigger). Azure Reaper will use your `az login` session to read tags, apply the `CloudReaperStatus` tag, and schedule deletion via the Durable Entity.
+Fire the modified payload against the local function app as described in [Testing the EventGrid Trigger](#testing-the-eventgrid-trigger). Cloud Reaper for Azure will use your `az login` session to read tags, apply the `CloudReaperStatus` tag, and schedule deletion via the Durable Entity.
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,10 @@ Cloud Reaper for Azure currently has the following limitations:
 
 | Description | Status |
 | ----- | ----- |
-| It is not possible to stop the deletion of a scheduled resource group. 😅 However, a lock can be applied to prevent deletion. | ✅ Workaround Available |
-| Cloud Reaper for Azure has only been tested with a single subscription. Multi-subscription support is planned. | 🔨 Planned Improvement |
-| Cloud Reaper for Azure operates only at the Azure Resource Group level, not on individual resources | 🗒️ Current Functionality |
-| Cloud Reaper for Azure uses UTC internally for all scheduling and timestamps (e.g. `CloudReaperDeletionTime`). There is currently no option to configure a different time zone. | 🗒️ Current Functionality |
-| Re-scheduling a deletion by updating the `CloudReaperLifetime` tag value after the resource group has already been scheduled is not supported. The original schedule remains active. | 🗒️ Current Functionality |
-| These limitations will be actively addressed in future updates to help make Cloud Reaper for Azure work and play better. |  |
+| Cloud Reaper for Azure has only been tested with a single subscription. Multi-subscription support is planned. | Planned Improvement |
+| Cloud Reaper for Azure operates only at the Azure Resource Group level, not on individual resources | Current Functionality |
+| Cloud Reaper for Azure uses UTC internally for all scheduling and timestamps (e.g. `CloudReaperDeletionTime`). There is currently no option to configure a different time zone. | Current Functionality |
+| Re-scheduling a deletion by updating the `CloudReaperLifetime` tag value after the resource group has already been scheduled is not supported. The original schedule remains active. | Current Functionality |
 ## Status
 Cloud Reaper for Azure is under active development and is constantly evolving. The capabilities and performance of the project are continually being improved.
 

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -13,6 +13,8 @@ resource "azurerm_storage_account" "reaper" {
   account_replication_type        = "LRS"
   account_kind                    = "StorageV2"
   allow_nested_items_to_be_public = false
+  https_traffic_only_enabled      = true
+  min_tls_version                 = "TLS1_2"
 
   tags = local.default_tags
 }
@@ -104,7 +106,7 @@ resource "azurerm_function_app_flex_consumption" "reaper" {
 # ==============================================================================
 
 resource "azurerm_role_definition" "reaper" {
-  name        = "Azure Reaper Operator"
+  name        = "Azure Reaper Operator (${var.AZURE_ENV_NAME})"
   scope       = "/subscriptions/${var.AZURE_SUBSCRIPTION_ID}"
   description = "Allows reading, tagging, and deleting resource groups for Azure Reaper"
 

--- a/readme_release_prep.md
+++ b/readme_release_prep.md
@@ -1,0 +1,151 @@
+# Azure Reaper v2.0.0 -- Pre-Release Review Report
+
+## Context
+
+This is a comprehensive pre-release review for the Azure Reaper v2.0.0. Three independent expert reviewers (DevOps, .NET Developer, Security) performed a full audit of the project. This plan consolidates all findings into a unified, prioritized action list for release preparation.
+
+---
+
+## Overall Ratings
+
+| Reviewer | Rating | Summary |
+|----------|--------|---------|
+| DevOps Expert | **6.0/10** | Strong IaC fundamentals, but no CI/CD or tests -- biggest gaps |
+| .NET Developer | **7.5/10** | Clean architecture with a critical scheduling bug and dead code |
+| Security Reviewer | **7.5/10** | Security-conscious design; needs infra hardening and safety guards |
+
+---
+
+## CRITICAL Findings (Must Fix Before Release)
+
+### C1. Durable Entity timer scheduling bug -- immediate deletion instead of delayed
+- **File:** `src/AzureReaper.Functions/Entities/AzureResourceEntity.cs:113-119`
+- **Issue:** `SignalEntityOptions` is passed as the `input` parameter instead of the `options` parameter to `Context.SignalEntity()`. The signal fires immediately (not on schedule) and `DeleteResourceAsync` receives a `SignalEntityOptions` object as input instead of `null`. **Every resource group will be deleted immediately after creation rather than after the configured lifetime.**
+- **Fix:** Change to `Context.SignalEntity(Context.Id, nameof(DeleteResourceAsync), input: null, options: signalOptions);`
+- **Source:** .NET Developer Review
+
+---
+
+## HIGH Findings (Should Fix Before Release)
+
+### H1. Entity state cleanup does not delete entities from storage
+- **File:** `src/AzureReaper.Functions/Entities/AzureResourceEntity.cs:45-46, 52-53, 174-175, 190`
+- **Issue:** `State = null!` resets state to default but does NOT remove the entity from durable storage. Leads to unbounded orphaned entity accumulation over time.
+- **Fix:** Use `Context.DeleteState()` or equivalent proper entity deletion API.
+
+### H2. Dead code: `StringHandler.cs` and unused `IResourcePayload` interface
+- **Files:** `src/AzureReaper.Functions/Common/StringHandler.cs`, `src/AzureReaper.Functions/Interfaces/IResourcePayload.cs`
+- **Issue:** `StringHandler.ExtractResourcePayload()` is never called. `IResourcePayload` is implemented by two classes but never used as a parameter type or constraint.
+- **Fix:** Remove both files (or integrate `StringHandler` if intended).
+
+### H3. No CI/CD pipelines exist
+- **Directory:** `.github/workflows/` (missing)
+- **Issue:** No automated builds, tests, linting, Terraform validation, or deployment pipelines. For a tool that deletes resource groups, this is a significant gap.
+- **Fix:** Create GitHub Actions workflows for: build+validate (on PR), deploy (on merge to main), release (on tag).
+
+### H4. No unit test project
+- **Issue:** The solution contains only the Functions project. Core logic (`TagHandler`, entity state transitions, event filtering) has zero automated test coverage.
+- **Fix:** Add a test project with unit tests for at minimum `TagHandler`, `AzureResourceEntity` state transitions, and EventGrid filtering logic.
+
+### H5. Terraform lock file version mismatch
+- **File:** `infra/.terraform.lock.hcl:25`
+- **Issue:** `time` provider constraint is `~> 0.12` in lock file but `~> 0.13` in `provider.tf`. Will cause `terraform init` failures.
+- **Fix:** Run `terraform init -upgrade` to regenerate the lock file.
+
+---
+
+## MEDIUM Findings (Recommended Before Release)
+
+### Infrastructure & DevOps
+
+| # | Finding | File | Fix |
+|---|---------|------|-----|
+| M1 | Custom role name `"Azure Reaper Operator"` is not unique per environment -- will collide if two envs deploy to same subscription | `infra/function.tf:107` | Append env name: `"Azure Reaper Operator - ${var.AZURE_ENV_NAME}"` |
+| M2 | No validation on `AZURE_ENV_NAME` variable -- long names could exceed Azure limits | `infra/variables.tf` | Add length validation |
+| M3 | Storage account missing network restrictions (publicly accessible) | `infra/function.tf:8-18` | Add `network_rules` block with `default_action = "Deny"` |
+| M4 | Storage account missing explicit `min_tls_version` and `https_traffic_only_enabled` | `infra/function.tf:8-18` | Add explicit settings |
+| M5 | Dependabot only covers devcontainers, not NuGet or Terraform | `.github/dependabot.yml` | Add `nuget` and `terraform` ecosystems |
+| M6 | Azurite Docker image uses `:latest` tag | `docker-compose.yml:2` | Pin to specific version |
+
+### Code Quality
+
+| # | Finding | File | Fix |
+|---|---------|------|-----|
+| M7 | `ResourcePayload` uses `required string?` -- contradictory; entity code uses `!` operator extensively assuming non-null | `src/.../Models/ResourcePayload.cs:8-10` | Change to `required string` (non-nullable) |
+| M8 | Pervasive null-forgiving `!` on entity state properties -- no guard if state is unexpectedly null | `src/.../Entities/AzureResourceEntity.cs` (7+ locations) | Add null guards or make state properties non-nullable |
+| M9 | Unnecessary ASP.NET Core / HTTP packages for a non-HTTP app | `src/.../AzureReaper.csproj:11,21-22` and `Program.cs:12` | Remove HTTP packages, switch `ConfigureFunctionsWebApplication()` to `ConfigureFunctionsWorkerDefaults()` |
+| M10 | No `CancellationToken` propagation in async methods | All async methods | Add `CancellationToken` to method signatures and pass to Azure SDK calls |
+
+### Safety & Security
+
+| # | Finding | File | Fix |
+|---|---------|------|-----|
+| M11 | No resource group exclusion/protection list -- reaper can delete its own RG | Architecture | Add configurable exclusion list; at minimum exclude the reaper's own RG |
+| M12 | No minimum lifetime cap -- tag value `1` schedules deletion in 1 minute | `src/.../Common/TagHandler.cs` | Add configurable minimum (e.g., 5 minutes) |
+| M13 | Re-entrant event loop from reaper's own tag writes (each tag update triggers EventGrid again) | Architecture | Add EventGrid advanced filtering or short-circuit check before entity signal |
+
+### Documentation
+
+| # | Finding | File | Fix |
+|---|---------|------|-----|
+| M14 | CLAUDE.md references `infra/main.bicep` -- project uses Terraform now | `.claude/CLAUDE.md:102` | Update to reference Terraform |
+| M15 | CLAUDE.md says "Planned: GitHub Actions for CI/CD" -- stale for v2.0.0 | `.claude/CLAUDE.md:128` | Update or remove |
+| M16 | README still has "major rewrite" warning banner | `README.md:7-8` | Remove or update for v2.0.0 |
+| M17 | DevContainer includes `ms-azuretools.vscode-bicep` extension -- no longer relevant | `.devcontainer/devcontainer.json:37` | Replace with `hashicorp.terraform` |
+
+---
+
+## LOW Findings (Nice to Have)
+
+| # | Finding | File |
+|---|---------|------|
+| L1 | No `lifecycle` blocks on Terraform resources (e.g., `prevent_destroy` on storage) | `infra/function.tf` |
+| L2 | Hardcoded `maximum_instance_count=100` and `instance_memory_in_mb=2048` -- should be variables | `infra/function.tf:77-78` |
+| L3 | Log Analytics retention hardcoded to 30 days | `infra/function.tf:33` |
+| L4 | No diagnostic settings on storage account or function app | `infra/function.tf` |
+| L5 | Inconsistent log prefixes (`[EntityTrigger]` vs class name pattern) | `AzureResourceEntity.cs` |
+| L6 | No upper bound on lifetime tag value | `TagHandler.cs` |
+| L7 | `launchSettings.json` port 7133 vs documentation/comments referencing 7071 | Multiple files |
+| L8 | `DefaultAzureCredential` registered without options -- probes unnecessary credential types | `Program.cs:18` |
+| L9 | `archive/` directory should be removed or moved for v2.0.0 release | Repo root |
+| L10 | No Terraform backend configured (state stored locally) | `infra/provider.tf` |
+
+---
+
+## Recommended Prioritization for v2.0.0
+
+### Phase 1: Showstoppers (block release)
+1. **C1** -- Fix the SignalEntity parameter bug (immediate deletion)
+2. **H1** -- Fix entity state cleanup (orphaned entities)
+3. **H5** -- Fix Terraform lock file mismatch
+
+### Phase 2: Code Cleanup (high value, low effort)
+4. **H2** -- Remove dead code (StringHandler, IResourcePayload)
+5. **M9** -- Remove unnecessary ASP.NET Core packages
+6. **M7/M8** -- Fix null safety in ResourcePayload and entity
+7. **M14-M17** -- Fix stale documentation
+
+### Phase 3: Safety Improvements
+8. **M11** -- Add resource group exclusion list (at minimum self-protection)
+9. **M12** -- Add minimum lifetime cap
+10. **M1** -- Make custom role name environment-unique
+
+### Phase 4: Infrastructure Hardening
+11. **M3/M4** -- Storage account network rules and TLS settings
+12. **M5/M6** -- Dependabot and Docker image pinning
+
+### Phase 5: CI/CD & Testing (can be post-release but recommended)
+13. **H3** -- Create GitHub Actions workflows
+14. **H4** -- Add unit test project
+
+---
+
+## Verification
+
+After implementing changes:
+1. `dotnet build` succeeds with no warnings
+2. `terraform init && terraform validate && terraform plan` succeeds in `infra/`
+3. Local testing with `func start` + Azurite -- create a resource group with `CloudReaperLifetime` tag and verify deletion is **scheduled** (not immediate)
+4. Verify entity cleanup by checking Azure Table Storage after entity completion
+5. Verify tag removal cancels scheduled deletion
+6. Review all documentation for accuracy


### PR DESCRIPTION
## Summary
- Harden storage account with explicit TLS 1.2 and HTTPS-only settings (M4)
- Make custom RBAC role name environment-unique to prevent collisions across deployments (M1)
- Expand Dependabot coverage to NuGet and Terraform ecosystems (M5)
- Include pre-release review report (`readme_release_prep.md`) with full audit findings

## Context
First batch of improvements from a comprehensive pre-release review performed by three independent expert reviewers (DevOps, .NET Developer, Security). The full report with all findings and prioritization is included in the PR.

## Test plan
- [x] Verify `terraform validate` passes in `infra/`
- [x] Verify `terraform plan` shows expected changes (role name, storage account settings)
- [x] Confirm Dependabot picks up NuGet and Terraform ecosystems after merge